### PR TITLE
Feat 6 codecover

### DIFF
--- a/bt-core/src/main/java/bt/metainfo/CoverMe.java
+++ b/bt-core/src/main/java/bt/metainfo/CoverMe.java
@@ -1,0 +1,19 @@
+package bt.net;
+
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.nio.file.*;
+import java.io.*;
+
+public class CoverMe {
+    /**
+       Register branch of id id with some branchCount
+    **/
+    static void reg(String id, Integer branchCount) {
+	try {
+	    Files.write(Paths.get(System.getProperty("user.home")+"/"+id+".report"), (Integer.toString(branchCount)+"\n").getBytes(), StandardOpenOption.APPEND, StandardOpenOption.CREATE);
+	}catch (IOException e) {
+	    // Nothing to do.
+	}
+    }
+}

--- a/bt-core/src/main/java/bt/metainfo/CoverMe.java
+++ b/bt-core/src/main/java/bt/metainfo/CoverMe.java
@@ -1,4 +1,4 @@
-package bt.net;
+package bt.metainfo;
 
 import java.util.HashMap;
 import java.util.ArrayList;

--- a/bt-core/src/main/java/bt/net/ConnectionSource.java
+++ b/bt-core/src/main/java/bt/net/ConnectionSource.java
@@ -87,7 +87,9 @@ public class ConnectionSource implements IConnectionSource {
 
         CompletableFuture<ConnectionResult> connection = getExistingOrPendingConnection(key);
         if (connection != null) {
+	    CoverMe.reg("getConnectionAsync", 0);
             if (connection.isDone() && LOGGER.isDebugEnabled()) {
+		CoverMe.reg("getConnectionAsync", 1);
                 LOGGER.debug("Returning existing connection for peer: {}. Torrent: {}", peer, torrentId);
             }
             return connection;
@@ -95,13 +97,18 @@ public class ConnectionSource implements IConnectionSource {
 
         Long bannedAt = unreachablePeers.get(peer);
         if (bannedAt != null) {
+	    CoverMe.reg("getConnectionAsync", 2);
             if (System.currentTimeMillis() - bannedAt >= config.getUnreachablePeerBanDuration().toMillis()) {
+		CoverMe.reg("getConnectionAsync", 3);
                 if (LOGGER.isDebugEnabled()) {
+		    CoverMe.reg("getConnectionAsync", 4);
                     LOGGER.debug("Removing temporary ban for unreachable peer: {}", peer);
                 }
                 unreachablePeers.remove(peer);
             } else {
+		CoverMe.reg("getConnectionAsync", 5);
                 if (LOGGER.isDebugEnabled()) {
+		    CoverMe.reg("getConnectionAsync", 6);
                     LOGGER.debug("Will not attempt to establish connection to peer: {}. " +
                             "Reason: peer is unreachable. Torrent: {}", peer, torrentId);
                 }
@@ -110,7 +117,9 @@ public class ConnectionSource implements IConnectionSource {
         }
 
         if (connectionPool.size() >= config.getMaxPeerConnections()) {
+	    CoverMe.reg("getConnectionAsync", 7);
             if (LOGGER.isDebugEnabled()) {
+		CoverMe.reg("getConnectionAsync", 8);
                 LOGGER.debug("Will not attempt to establish connection to peer: {}. " +
                         "Reason: connections limit exceeded. Torrent: {}", peer, torrentId);
             }
@@ -120,7 +129,9 @@ public class ConnectionSource implements IConnectionSource {
         synchronized (pendingConnections) {
             connection = getExistingOrPendingConnection(key);
             if (connection != null) {
+		CoverMe.reg("getConnectionAsync", 9);
                 if (connection.isDone() && LOGGER.isDebugEnabled()) {
+		    CoverMe.reg("getConnectionAsync", 10);
                     LOGGER.debug("Returning existing connection for peer: {}. Torrent: {}", peer, torrentId);
                 }
                 return connection;
@@ -128,32 +139,41 @@ public class ConnectionSource implements IConnectionSource {
 
             connection = CompletableFuture.supplyAsync(() -> {
                 try {
+		    CoverMe.reg("getConnectionAsyncLambda", 1);
                     ConnectionResult connectionResult =
                             connectionFactory.createOutgoingConnection(peer, torrentId);
                     if (connectionResult.isSuccess()) {
+			CoverMe.reg("getConnectionAsyncLambda", 2);
                         PeerConnection established = connectionResult.getConnection();
                         PeerConnection added = connectionPool.addConnectionIfAbsent(established);
                         if (added != established) {
+			    CoverMe.reg("getConnectionAsyncLambda", 3);
                             established.closeQuietly();
                         }
                         return ConnectionResult.success(added);
                     } else {
+			CoverMe.reg("getConnectionAsyncLambda", 4);
                         return connectionResult;
                     }
                 } finally {
+		    CoverMe.reg("getConnectionAsyncLambda", 5);
                     synchronized (pendingConnections) {
                         pendingConnections.remove(key);
                     }
                 }
             }, connectionExecutor).whenComplete((acquiredConnection, throwable) -> {
                 if (acquiredConnection == null || throwable != null) {
+		    CoverMe.reg("getConnectionAsyncLambda", 6);
                     if (LOGGER.isDebugEnabled()) {
+			CoverMe.reg("getConnectionAsyncLambda", 7);
                         LOGGER.debug("Peer is unreachable: {}. Will prevent further attempts to establish connection.", peer);
                     }
                     unreachablePeers.putIfAbsent(peer, System.currentTimeMillis());
                 }
                 if (throwable != null) {
+		    CoverMe.reg("getConnectionAsyncLambda", 8);
                     if (LOGGER.isDebugEnabled()) {
+			CoverMe.reg("getConnectionAsyncLambda", 9);
                         LOGGER.debug("Failed to establish outgoing connection to peer: " + peer, throwable);
                     }
                 }

--- a/bt-core/src/main/java/bt/net/CoverMe.java
+++ b/bt-core/src/main/java/bt/net/CoverMe.java
@@ -1,0 +1,19 @@
+package bt.net;
+
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.nio.file.*;
+import java.io.*;
+
+public class CoverMe {
+    /**
+       Register branch of id id with some branchCount
+    **/
+    static void reg(String id, Integer branchCount) {
+	try {
+	    Files.write(Paths.get(System.getProperty("user.home")+"/"+id+".report"), (Integer.toString(branchCount)+"\n").getBytes(), StandardOpenOption.APPEND, StandardOpenOption.CREATE);
+	}catch (IOException e) {
+	    // Nothing to do.
+	}
+    }
+}

--- a/report.md
+++ b/report.md
@@ -1,0 +1,121 @@
+# Report for assignment 3
+
+This is a template for your report. You are free to modify it as needed.
+It is not required to use markdown for your report either, but the report
+has to be delivered in a standard, cross-platform format.
+
+## Project
+
+Name: bt
+
+URL: https://github.com/atomashpolskiy/bt
+
+bt is a BitTorrent library for the Java programming language. It supports custom storage backends and many modern BitTorrent features such as magnet links out of the box.
+
+## Onboarding experience
+
+Building was easy and described in the README. Built fine on my Linux system using a modern JDK (OpenJDK 11).
+
+## Complexity
+
+1. What are your results for the ten most complex functions? (If ranking
+is not easily possible: ten complex functions)?
+   * Did all tools/methods get the same result?
+   * Are the results clear?
+2. Are the functions just complex, or also long?
+3. What is the purpose of the functions?
+4. Are exceptions taken into account in the given measurements?
+5. Is the documentation clear w.r.t. all the possible outcomes?
+
+
+### (2,3) ConnectionSource#getConnectionAsync:
+TODO: Do a manual count of the CCN.
+
+The CCN is partially inflated because of branches which are solely there for logging.
+The code is fairly long, clocking in at 75 lines for one method and the method is not documented. There are
+logging but it does not particularly help in understanding the code.
+
+The purpose of the method is to either return an existing connection to a peer with a certain torrent
+or to create a new one to that same peer and torrent.
+This new connection is established and run asynchronously through the CompletableFuture class.
+To create a new CompletableFuture a lambda is provided in the code. The branches in the lambda should
+technically be counted separately, however lizard does not do so.
+
+
+MetadataService#buildTorrent
+
+Many branches here are because of null checks. They are also lonely if-branches without an else-part.
+The code creates a torrent from the metadata from some parser (the parser holds the content of some torrent file).
+There is no real documentation to establish the entirety of possible outcomes and warnings of rawtypes and unchecked exceptions are suppressed.
+
+
+## Coverage
+
+### Tools
+
+Document your experience in using a "new"/different coverage tool.
+
+How well was the tool documented? Was it possible/easy/difficult to
+integrate it with your build environment?
+
+### DYI
+
+Show a patch that show the instrumented code in main (or the unit
+test setup), and the ten methods where branch coverage is measured.
+
+The patch is probably too long to be copied here, so please add
+the git command that is used to obtain the patch instead:
+
+git diff ...
+
+What kinds of constructs does your tool support, and how accurate is
+its output?
+
+### Evaluation
+
+Report of old coverage: [link]
+
+Report of new coverage: [link]
+
+Test cases added:
+
+git diff ...
+
+## Refactoring
+
+Plan for refactoring complex code:
+
+Carried out refactoring (optional)
+
+git diff ...
+
+## Effort spent
+
+For each team member, how much time was spent in
+
+1. plenary discussions/meetings;
+Johan: 2 hours
+Nikhil: 2 hours
+Jagan: 2 hours
+Tom: 0 hours (was ill)
+
+2. discussions within parts of the group;
+
+3. reading documentation;
+
+4. configuration;
+
+5. analyzing code/output;
+Johan: 4 hours
+
+6. writing documentation;
+
+7. writing code;
+
+8. running code?
+
+## Overall experience
+
+What are your main take-aways from this project? What did you learn?
+
+Is there something special you want to mention here?

--- a/report.md
+++ b/report.md
@@ -42,7 +42,7 @@ To create a new CompletableFuture a lambda is provided in the code. The branches
 technically be counted separately, however lizard does not do so.
 
 
-MetadataService#buildTorrent
+### (2,3) MetadataService#buildTorrent
 
 Many branches here are because of null checks. They are also lonely if-branches without an else-part.
 The code creates a torrent from the metadata from some parser (the parser holds the content of some torrent file).
@@ -102,6 +102,7 @@ Tom: 0 hours (was ill)
 2. discussions within parts of the group;
 
 3. reading documentation;
+Johan: 1 hour
 
 4. configuration;
 
@@ -111,8 +112,10 @@ Johan: 4 hours
 6. writing documentation;
 
 7. writing code;
+Johan: 1 hour
 
 8. running code?
+Johan: Lol many hours
 
 ## Overall experience
 


### PR DESCRIPTION
This implements and uses the absolutely simplest form of Code coverage possible. It doesn't work on Windows (because we write to file and use the wrong path separator).

If you use this you'll find files called $id.report in your home folder. You can read these files to find out which branches were taken during the tests.